### PR TITLE
Ignoring .elixir_ls folder from git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 .DS_Store
+.elixir_ls


### PR DESCRIPTION
Newer versions of elixir uses .elixir_ls folder to put dist files and should not be committed.