### PR TITLE
add parentheses to module metadata function calls

### DIFF
--- a/lib/remodel/formatters/list_formatter.ex
+++ b/lib/remodel/formatters/list_formatter.ex
@@ -13,13 +13,13 @@ defmodule Remodel.Formatter.ListFormatter do
     do: Enum.map(resources, fn(resource) -> format_resources(resource, serializer, options) end)
 
   defp format_resources(resource, serializer, options) do
-    Enum.map serializer.__attributes(), fn(attr) ->
+    Enum.map(serializer.__attributes(), fn(attr) ->
       if !attr.if || apply(serializer, attr.if, [resource, options[:scope]]) do
         apply(serializer, attr.attribute, [resource, options[:scope]])
       else
         nil
       end
-    end
+    end)
   end
 
   defp format_header(serializer),

--- a/lib/remodel/formatters/list_formatter.ex
+++ b/lib/remodel/formatters/list_formatter.ex
@@ -13,7 +13,7 @@ defmodule Remodel.Formatter.ListFormatter do
     do: Enum.map(resources, fn(resource) -> format_resources(resource, serializer, options) end)
 
   defp format_resources(resource, serializer, options) do
-    Enum.map serializer.__attributes, fn(attr) ->
+    Enum.map serializer.__attributes(), fn(attr) ->
       if !attr.if || apply(serializer, attr.if, [resource, options[:scope]]) do
         apply(serializer, attr.attribute, [resource, options[:scope]])
       else
@@ -23,5 +23,5 @@ defmodule Remodel.Formatter.ListFormatter do
   end
 
   defp format_header(serializer),
-    do: Enum.map(serializer.__attributes, fn(attr) -> to_string(attr.as || attr.attribute) end)
+    do: Enum.map(serializer.__attributes(), fn(attr) -> to_string(attr.as || attr.attribute) end)
 end

--- a/lib/remodel/formatters/map_formatter.ex
+++ b/lib/remodel/formatters/map_formatter.ex
@@ -11,7 +11,7 @@ defmodule Remodel.Formatter.MapFormatter do
   end
 
   defp format_resource(resource, serializer, options) when is_map(resource) do
-    Enum.reduce(serializer.__attributes, %{}, fn(attr, results) ->
+    Enum.reduce(serializer.__attributes(), %{}, fn(attr, results) ->
       if !attr.if || evaluate_conditional(resource, serializer, options, attr) do
         Map.put(results, attr.as || attr.attribute, apply(serializer, attr.attribute, [resource, options[:scope]]))
       else


### PR DESCRIPTION
The elixir 1.17.3 compiler prints a warning for these:

```
warning: using map.field notation (without parentheses) to invoke function MySerializer.__attributes() is deprecated, you must add parentheses instead: remote.function()
  (remodel 0.0.4) lib/remodel/formatters/map_formatter.ex:14: Remodel.Formatter.MapFormatter.format_resource/3
  (remodel 0.0.4) lib/remodel/formatters/map_formatter.ex:3: Remodel.Formatter.MapFormatter.format/3
```